### PR TITLE
Fix issue not listing all dependencies

### DIFF
--- a/bin/git-vendor
+++ b/bin/git-vendor
@@ -97,8 +97,7 @@ git-vendor-ref: $ref
 cmd_list()
 {
     showOnly="$1"
-    vendorNames=$(vendor_names_from_log)
-    for name in "${vendorNames[@]}";
+    for name in $(vendor_names_from_log);
     do
         vendor_git_log_first "$name" |
 	    while read a b junk; do


### PR DESCRIPTION
We found that `git-vendor list` was not working as expected. The problem was with how we were iterating over the list of found dependencies. When iterating over the list, we were not iterating over each individual dependency, instead we were iterating over the whole list as one.

Fixes #4
