### PR TITLE
Fetch the last rev before pulling

### DIFF
--- a/bin/git-vendor
+++ b/bin/git-vendor
@@ -148,6 +148,7 @@ cmd_update()
 		START) ;;
                 git-vendor-dir:) dir="$b" ;;
 		git-vendor-repository:) repository="$b" ;;
+		git-vendor-ref:) curr_ref="$b" ;;
 		END)
                     # Make sure the dependency exists on disk
                     if [ ! -d "$dir" ]; then
@@ -164,6 +165,7 @@ git-vendor-dir: $dir
 git-vendor-repository: $repository
 git-vendor-ref: $ref
 "
+                        git fetch "$repository" "$curr_ref"
                         git subtree pull --prefix "$dir" --message "$message" "$repository" "$ref" --squash
                         break
                     fi


### PR DESCRIPTION
`git subtree pull` does not fetch before merging. As a result, the following error can be thrown when attempting to run `git vendor update` from a fresh clone. This primarily happens if the pull is not clean, i.e. involves `REVERT`s, and the `git-subtree-split` hash does not exist in the upstream commit history.

```bash
fatal: ambiguous argument '59a83c70a7738ad1e5eb51d55f38827620c0a6df^0': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
could not rev-parse split hash 59a83c70a7738ad1e5eb51d55f38827620c0a6df from commit c8f1650194712949c19b1400c7ce18f810447b77
```

This should also fix #10.

Steps to repro:
1. Checkout https://github.com/sjk4sc/git-vendor-bug-repro
2. Run `git vendor update git-vendor v1.0.0` (going back a version)