### PR TITLE
support ssh repos

### DIFF
--- a/bin/git-vendor
+++ b/bin/git-vendor
@@ -80,7 +80,7 @@ cmd_add()
         die "Incorrect options provided: git vendor add <name> <repository> [<ref>]"
     fi
 
-    dir="$prefix/$(echo "$repository" | sed -E 's/^[a-zA-Z]+((:\/\/)|@)//' | sed 's/:/\//' | sed -E 's/\.git$//')"
+    dir="$prefix/$(echo "$repository" | sed -E 's/^[a-zA-Z]+((:\/\/)|@|(:\/\/git@))//' | sed -E 's/:[0-9]+//' | sed -E 's/\.git$//')"
     message="\
 Add \"$name\" from \"$repository@$ref\"
 


### PR DESCRIPTION
support repositories with SSH URLs.
e.g. given repository URL `ssh://git@some.domain.com:7999/project/cool-stuff.git`
before the change the resulting directory will be: `vendor/git@some.domain.com/7999/project/cool-stuff`
the directory after this change will be: `                 `vendor/some.domain.com/project/cool-stuff``

summary:
- handle the `git@` URL prefix
- drop the port number from the directory name as it does not contribute to understanding. The port number info is retained elsewhere for future updates/syncs.