### PR TITLE
Bugfix: fix integration with git command -h

### DIFF
--- a/bin/git-vendor
+++ b/bin/git-vendor
@@ -16,13 +16,13 @@ Usage:
 EOF
 }
 
+case "$1" in
+    ""|"-h"|"--help") _usage && exit ;;
+esac
+
 PATH=$PATH:$(git --exec-path)
 . git-sh-setup
 require_work_tree
-
-case "$1" in
-    ""|"--help") _usage && exit ;;
-esac
 
 command="$1"
 shift


### PR DESCRIPTION
"git vendor -h" produces an unhelpful message:

  $ git vendor -h
  usage: git vendor

Move some code so a proper usage message will be issued.

Note that "git vendor --help" is processed by the "git" binary (not
"git-vendor") and thus is unaffected by this change.